### PR TITLE
Repair broken "Careers" link

### DIFF
--- a/index.html
+++ b/index.html
@@ -256,7 +256,7 @@
                 <div class="col-lg-6 text-center">
                     <h2 class="section-heading">#JoinTheDude</h2>
                     <p>We're always on the lookout for great people to work with. We'd love to meet you!</p>
-                    <a href="https://sdcareers-dudesolutions.icims.com/jobs/intro" class="btn btn-primary btn-xl">View Current Openings!</a>
+                    <a href="https://www.dudesolutions.com/about-us/careers" class="btn btn-primary btn-xl">View Current Openings!</a>
                 </div>
                 <div class="col-lg-6 text-center">
                     <a class="twitter-timeline" href="https://twitter.com/hashtag/JoinTheDude" data-widget-id="666335403570393090">#JoinTheDude Tweets</a>


### PR DESCRIPTION
- Old careers link was pointing to a de-funct icims site
- Refactored the link to point to the Careers site on corporate dude solutions website, to eliminate any future brittleness